### PR TITLE
Prepare for version 1.0.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.phoenicis</groupId>
     <artifactId>phoenicis-javafx-collections</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>1.0.0</version>
 
     <name>Additional JavaFX collections library</name>
 


### PR DESCRIPTION
I think the repository is ready for its first release (version `1.0.0`).
Sadly I couldn't get #7 to work, but I think it can wait until a later release.

@plata, @qparis do you think there is anything missing before a release?