### PR TITLE
Fix inner ObservableList equality problem in ConcatenatedList

### DIFF
--- a/src/test/java/org/phoenicis/javafx/collections/ConcatenatedListTest.java
+++ b/src/test/java/org/phoenicis/javafx/collections/ConcatenatedListTest.java
@@ -204,7 +204,33 @@ public class ConcatenatedListTest {
     }
 
     @Test
-    public void testInnerListRemove1() {
+    public void testInnerListAddWithEqualInnerLists() {
+        ObservableList<String> list1 = FXCollections.observableArrayList("11");
+        ObservableList<String> list2 = FXCollections.observableArrayList("41");
+        ObservableList<String> list3 = FXCollections.observableArrayList("31");
+        ObservableList<String> list4 = FXCollections.observableArrayList();
+
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>>builder()
+                        .add(list1).add(list2).add(list3).add(list4).build());
+        ConcatenatedList<String> mappedList = new ConcatenatedList<>(observableList);
+
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, mappedList);
+
+        assertEquals(Arrays.asList("11", "41", "31"), mappedList);
+        assertEquals(Arrays.asList("11", "41", "31"), actual);
+
+        // list2 and list4 are equal after the add operation
+        list4.add("41");
+
+        assertEquals(Arrays.asList("11", "41", "31", "41"), mappedList);
+        assertEquals(Arrays.asList("11", "41", "31", "41"), actual);
+    }
+
+    @Test
+    public void testInnerListRemove() {
         ObservableList<String> list1 = FXCollections.observableArrayList("11");
         ObservableList<String> list2 = FXCollections.observableArrayList("21", "22");
         ObservableList<String> list3 = FXCollections.observableArrayList("31");
@@ -228,7 +254,7 @@ public class ConcatenatedListTest {
     }
 
     @Test
-    public void testInnerListRemove2() {
+    public void testInnerListRemoveWithEqualInnerLists() {
         ObservableList<String> list1 = FXCollections.observableArrayList("11");
         ObservableList<String> list2 = FXCollections.observableArrayList();
         ObservableList<String> list3 = FXCollections.observableArrayList("31");
@@ -246,6 +272,7 @@ public class ConcatenatedListTest {
         assertEquals(Arrays.asList("11", "31", "41"), mappedList);
         assertEquals(Arrays.asList("11", "31", "41"), actual);
 
+        // list2 and list4 are equal after the clear operation
         list4.clear();
 
         assertEquals(Arrays.asList("11", "31"), mappedList);

--- a/src/test/java/org/phoenicis/javafx/collections/ConcatenatedListTest.java
+++ b/src/test/java/org/phoenicis/javafx/collections/ConcatenatedListTest.java
@@ -204,7 +204,7 @@ public class ConcatenatedListTest {
     }
 
     @Test
-    public void testInnerListRemove() {
+    public void testInnerListRemove1() {
         ObservableList<String> list1 = FXCollections.observableArrayList("11");
         ObservableList<String> list2 = FXCollections.observableArrayList("21", "22");
         ObservableList<String> list3 = FXCollections.observableArrayList("31");
@@ -225,6 +225,31 @@ public class ConcatenatedListTest {
 
         assertEquals(Arrays.asList("11", "22", "31"), mappedList);
         assertEquals(Arrays.asList("11", "22", "31"), actual);
+    }
+
+    @Test
+    public void testInnerListRemove2() {
+        ObservableList<String> list1 = FXCollections.observableArrayList("11");
+        ObservableList<String> list2 = FXCollections.observableArrayList();
+        ObservableList<String> list3 = FXCollections.observableArrayList("31");
+        ObservableList<String> list4 = FXCollections.observableArrayList("41");
+
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>>builder()
+                        .add(list1).add(list2).add(list3).add(list4).build());
+        ConcatenatedList<String> mappedList = new ConcatenatedList<>(observableList);
+
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, mappedList);
+
+        assertEquals(Arrays.asList("11", "31", "41"), mappedList);
+        assertEquals(Arrays.asList("11", "31", "41"), actual);
+
+        list4.clear();
+
+        assertEquals(Arrays.asList("11", "31"), mappedList);
+        assertEquals(Arrays.asList("11", "31"), actual);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes a problem in the `ConcatenatedList` that occurred if it contains two inner `ObservableList`s which are equal (i.e. `list1.equals(list2)`). In such a situation it is possible that the wrong base index of the inner list is taken when changes to the inner lists are detected.