### PR TITLE
Rename module to "org.phoenicis.javafx.collections"

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,4 @@
-module javafx.collections {
+module org.phoenicis.javafx.collections {
     exports org.phoenicis.javafx.collections;
     opens org.phoenicis.javafx.collections;
     requires com.google.common;


### PR DESCRIPTION
This PR renames the java module to `org.phoenicis.javafx.collections` and closes #11.