### PR TITLE
Prepare for version 1.1.0 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>org.phoenicis</groupId>
     <artifactId>phoenicis-javafx-collections</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>1.1.0</version>
 
     <name>Additional JavaFX collections library</name>
 


### PR DESCRIPTION
The new release:
- contains a bugfix (see #15)
- changes the module name from `javafx.collections` to `org.phoenicis.javafx.collections`
- some small refactoring