### PR TITLE
Replace internal Map with a List in ConcatenatedList

### DIFF
--- a/src/main/java/org/phoenicis/javafx/collections/ConcatenatedList.java
+++ b/src/main/java/org/phoenicis/javafx/collections/ConcatenatedList.java
@@ -19,8 +19,8 @@ import java.util.stream.IntStream;
  */
 public class ConcatenatedList<E> extends TransformationListBase<E, ObservableList<? extends E>> {
     /**
-     * A map linking the created {@link ListChangeListener} instances to their corresponding {@link ObservableList}.
-     * This map is required to allow for the removal of the listener when an {@link ObservableList} is removed
+     * A list containing the created {@link ListChangeListener} instances for the {@link ObservableList}s in the source list.
+     * This list is required to allow for the removal of a listener when an {@link ObservableList} is removed
      */
     private final List<ListChangeListener<E>> innerListeners;
 
@@ -382,7 +382,8 @@ public class ConcatenatedList<E> extends TransformationListBase<E, ObservableLis
     /**
      * Removes the {@link ListChangeListener} from the given {@link ObservableList innerList}
      *
-     * @param innerList The {@link ObservableList} from which the {@link ListChangeListener} should be removed
+     * @param innerList      The {@link ObservableList} from which the {@link ListChangeListener} should be removed
+     * @param innerListIndex The index of the to be removed {@link ObservableList innerList}
      */
     private void removeUpdateListener(final ObservableList<? extends E> innerList, final int innerListIndex) {
         final ListChangeListener<E> innerListener = innerListeners.remove(innerListIndex);

--- a/src/test/java/org/phoenicis/javafx/collections/ConcatenatedListTest.java
+++ b/src/test/java/org/phoenicis/javafx/collections/ConcatenatedListTest.java
@@ -47,6 +47,27 @@ public class ConcatenatedListTest {
     }
 
     @Test
+    public void testListAddDuplicate() {
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>>builder()
+                        .add(FXCollections.observableArrayList("11"))
+                        .add(FXCollections.observableArrayList("21", "22"))
+                        .add(FXCollections.observableArrayList()).build());
+        ConcatenatedList<String> mappedList = new ConcatenatedList<>(observableList);
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, mappedList);
+
+        assertEquals(Arrays.asList("11", "21", "22"), mappedList);
+        assertEquals(Arrays.asList("11", "21", "22"), actual);
+
+        observableList.add(0, FXCollections.observableArrayList("21", "22"));
+
+        assertEquals(Arrays.asList("21", "22", "11", "21", "22"), mappedList);
+        assertEquals(Arrays.asList("21", "22", "11", "21", "22"), actual);
+    }
+
+    @Test
     public void testListRemoveFirstList() {
         ObservableList<ObservableList<String>> observableList = FXCollections
                 .observableArrayList(ImmutableList.<ObservableList<String>>builder()
@@ -107,6 +128,32 @@ public class ConcatenatedListTest {
 
         assertEquals(Arrays.asList("11", "21", "22"), mappedList);
         assertEquals(Arrays.asList("11", "21", "22"), actual);
+    }
+
+    @Test
+    public void testListRemoveDuplicateList() {
+        ObservableList<ObservableList<String>> observableList = FXCollections
+                .observableArrayList(ImmutableList.<ObservableList<String>>builder()
+                        .add(FXCollections.observableArrayList("11"))
+                        .add(FXCollections.observableArrayList("21", "22"))
+                        .add(FXCollections.observableArrayList("11")).build());
+        ConcatenatedList<String> mappedList = new ConcatenatedList<>(observableList);
+        List<String> actual = new ArrayList<>();
+
+        Bindings.bindContent(actual, mappedList);
+
+        assertEquals(Arrays.asList("11", "21", "22", "11"), mappedList);
+        assertEquals(Arrays.asList("11", "21", "22", "11"), actual);
+
+        observableList.remove(2);
+
+        assertEquals(Arrays.asList("11", "21", "22"), mappedList);
+        assertEquals(Arrays.asList("11", "21", "22"), actual);
+
+        observableList.remove(0);
+
+        assertEquals(Arrays.asList("21", "22"), mappedList);
+        assertEquals(Arrays.asList("21", "22"), actual);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes #21 by replacing the internal `Map` in `ConcatenatedList` with a `List`